### PR TITLE
close response body after http request

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,6 +88,9 @@ func (c *Client) tryNotifying(json []byte) error {
 	if err != nil {
 		return err
 	}
+
+	response.Body.Close()
+
 	if response.StatusCode == 401 {
 		authError := errors.New("Could not authenticate yeller client. Check your API key and that your subscription is active")
 		c.errorHandler.HandleAuthError(authError)


### PR DESCRIPTION
Without closing the response body, we were hitting too many file open errors on machines running this library. This commit should fix that. According to the docs, the http response always returns a body regardless of status or errors being generated.

